### PR TITLE
Add GitHub Actions for automatic release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,44 @@
+# .github/workflows/publish-release.yml
+name: Publish release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  check-permission:
+    name: check permission
+    runs-on: ubuntu-latest
+    outputs:
+      permission: ${{ steps.check.outputs.permission }}
+    steps:
+      - id: check
+        uses: shogo82148/actions-check-permissions@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    needs:
+      - check-permission
+    steps:
+        ##########################
+        # Checkout the code base #
+        ##########################
+      - name: Checkout code
+        uses: actions/checkout@v4
+        ##########################
+        # Release from tags      #
+        ##########################
+      - name: Publish Release
+        id: publish_release
+        uses: ghalactic/github-release-from-tag@v5
+        if: github.ref_type == 'tag'
+        with:
+          prerelease: "false"
+          reactions: rocket
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hello, when I first discovered this project, it seemed like a product still under development as there were no releases yet. So, I wanted to make a small contribution: I've added GitHub Actions for automated releases. 

# What I added
* [ghalactic/github-release-from-tag](https://github.com/ghalactic/github-release-from-tag?tab=readme-ov-file)
# How to use it
  1. Add Git alias for [Markdown support](https://github.com/ghalactic/github-release-from-tag?tab=readme-ov-file#markdown-support)
  2. When adding tags use following commands. Change `v0.6.3` to whatever, but with 'v' prefix (ref. [this section](https://github.com/ghalactic/github-release-from-tag?tab=readme-ov-file#release-stability))
  ```
  git tag-md v0.6.3
  ```
  3. Write subject and body as you want using Markdown. For example:
  ```
  OmniTool 0.6.3 Update

  # Development Updates: Enhanced Automation

  *  Added GitHub Actions for Improved Workflow
    *  Automated Deployment: Enables automatic release generation
  ```
  4. [Final result](https://github.com/appleparan/omnitool/releases/tag/v0.6.3)
  5. I have set it up to automatically add reactions, but if you don't want them, you can remove `reactions: +1, laugh, hooray, heart, rocket, eyes` from `.github/workflows/publish-release.yml`

# How to test locally
* You can test with [act](https://github.com/nektos/act), but this only tests if the workflow runs successful and does not test detailed aspects like formatting.